### PR TITLE
feat(select)!: Increase number of input letters if #items exceeds #keys

### DIFF
--- a/lua/fastaction/keys.lua
+++ b/lua/fastaction/keys.lua
@@ -6,13 +6,18 @@ local m = {}
 function m.get_action_config_from_title(params)
     if params.title == nil or params.title == '' then return nil end
     local index = 1
+    local increment = params.chars
     params.title = string.lower(params.title)
     repeat
-        local char = params.title:sub(index, index)
-        if char:match '[a-z]' and not vim.tbl_contains(params.invalid_keys, char) then
+        local char = params.title:sub(index, index + increment - 1)
+        if
+            char:match '[a-z]+'
+            and not vim.tbl_contains(params.invalid_keys, char)
+            and vim.tbl_contains(params.valid_keys, char)
+        then
             return { key = char, order = 0 }
         end
-        index = index + 1
+        index = index + increment
     until index >= #params.title
 end
 

--- a/lua/fastaction/types.lua
+++ b/lua/fastaction/types.lua
@@ -4,6 +4,7 @@
 ---@field override_function? fun(params: GetActionConfigParams): ActionConfig | nil
 ---@field priorities? ActionConfig[]
 ---@field valid_keys? string[]
+---@field chars integer
 
 ---@class CodeAction: lsp.CodeAction
 ---@field client_id integer
@@ -25,11 +26,13 @@
 ---@field highlight table<string, string>
 ---@field relative? string
 ---@field hide_cursor? boolean
+---@field chars integer
 
 ---@class SelectOpts
 ---@field prompt? string
 ---@field format_item? fun(item: any): string
 ---@field kind? string
+---@field chars integer
 
 ---@class FastActionConfig
 ---Configures options for the code action and select popups.

--- a/lua/fastaction/util.lua
+++ b/lua/fastaction/util.lua
@@ -1,0 +1,29 @@
+local M = {}
+
+---Generate n-letter permutations given a list of letters
+---@param letters string[]
+---@param n integer
+---@return string[]
+function M.generatePermutations(letters, n)
+    local permutations = {}
+
+    -- Helper function to generate permutations recursively
+    local function permute(current, remaining)
+        if #current == n then
+            table.insert(permutations, current)
+            return
+        end
+        for i = 1, #remaining do
+            local nextCurrent = current .. remaining[i]
+            local nextRemaining = {}
+            for j = 1, #remaining do
+                if i ~= j then table.insert(nextRemaining, remaining[j]) end
+            end
+            permute(nextCurrent, nextRemaining)
+        end
+    end
+    permute('', letters)
+    return permutations
+end
+
+return M

--- a/lua/fastaction/window.lua
+++ b/lua/fastaction/window.lua
@@ -108,7 +108,7 @@ function M.popup_window(content, on_buf_create, opts)
 
     local line = 2 -- avoid the title and the divider i.e. start at line 2
     for _, _ in pairs(content) do
-        vim.api.nvim_buf_add_highlight(buffer, m.namespace, 'MoreMsg', line, 0, 4)
+        vim.api.nvim_buf_add_highlight(buffer, m.namespace, 'MoreMsg', line, 0, 3 + opts.chars)
         line = line + 1
     end
     vim.api.nvim_set_option_value('modifiable', false, { buf = buffer })


### PR DESCRIPTION
This pr addresses a bug described in #6 where the plugin fails to map a key to a select item when the number of items exceeds the number of available keys.

This is fixed by increasing the pool of available keys by calculating n-letter permutations of those keys until the length of keys >= number of items.