### PR TITLE
fix: Use offset encoding of first client

### DIFF
--- a/lua/fastaction/types.lua
+++ b/lua/fastaction/types.lua
@@ -67,4 +67,9 @@
 ---Configures the vertical position of the popup with respect to the relative value.
 ---@field y_offset? integer | fun(height: integer): integer
 
+---@class lsp.CodeACtionParams
+---@field context lsp.CodeActionContext
+---@field range lsp.Range
+---@field textDocument lsp.TextDocumentIdentifier
+
 ---@alias Priority table<string, ActionConfig[]>


### PR DESCRIPTION
I fixed this error(position_encoding param is required in vim.lsp.util.make_range_params. Defaulting to position encoding of the first client.) that was occurring on nightly.

If using the 'stable release' version, there were no arguments for make_range_params, so it was not necessary to branch by version.

ref: https://github.com/neovim/neovim/pull/31249