### PR TITLE
Add options to customize select options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Using `lazy.nvim`
     -- },
   },
  register_ui_select = false,
+ format_right_section = nil
 }
 ```
 

--- a/lua/fastaction/config.lua
+++ b/lua/fastaction/config.lua
@@ -20,6 +20,7 @@ m.defaults = {
     priority = { default = {} },
     register_ui_select = false,
     fallback_threshold = 26,
+    format_right_section = nil,
 }
 
 ---@type FastActionConfig

--- a/lua/fastaction/types.lua
+++ b/lua/fastaction/types.lua
@@ -48,6 +48,7 @@
 ---Configures number of options after which fastaction must fallback on
 ---`vim.ui.select`
 ---@field fallback_threshold? integer
+---@field format_right_section? fun(item: LspCodeActionItem): string
 
 ---@class PopupConfig
 ---Title of the popup.


### PR DESCRIPTION
Hey @Chaitanyabsprip,
First of all, great work on this plugin!

I made some modifications for my own use and wanted to contribute them back in case you find them useful.

This PR introduces:
- Customization of the option text
- A new right_section, which allows users to add a text section aligned to the right

I'm using this feature to display the name of the LSP client in the option.
![image](https://github.com/user-attachments/assets/e1dcd309-743f-4a82-b509-d07bce4b8f71)

You can check my config [here](https://github.com/joaovfsousa/dotfiles/blob/main/config/nvim/lua/joaovfsousa/plugins/local-plugins.lua#L15)