### PR TITLE
feat: customize brackets around keys

### DIFF
--- a/lua/fastaction/config.lua
+++ b/lua/fastaction/config.lua
@@ -3,6 +3,7 @@ local m = {}
 
 ---@type FastActionConfig
 m.defaults = {
+    brackets = { '[', ']' },
     dismiss_keys = { 'j', 'k', '<c-c>', 'q' },
     keys = 'fjdkslaghrueiwocnxvbmztyqp',
     override_function = function(_) end,

--- a/lua/fastaction/init.lua
+++ b/lua/fastaction/init.lua
@@ -103,12 +103,16 @@ function M.select(items, opts, on_choice)
         if char_count > largest_char_count then largest_char_count = char_count end
     end
 
+    local brackets = config.get().brackets or { '[', ']' }
+
     for i, option in ipairs(options) do
         local spacing = largest_char_count + 1 - option.char_count
 
         content[i] = string.format(
-            '[%s] %s%s%s',
+            '%s%s%s %s%s%s',
+            brackets[1],
             option.key,
+            brackets[2],
             option.name,
             string.rep(' ', spacing),
             option.right_section

--- a/lua/fastaction/types.lua
+++ b/lua/fastaction/types.lua
@@ -49,6 +49,7 @@
 ---`vim.ui.select`
 ---@field fallback_threshold? integer
 ---@field format_right_section? fun(item: LspCodeActionItem): string
+---@field brackets table<string, string>
 
 ---@class PopupConfig
 ---Title of the popup.

--- a/lua/fastaction/window.lua
+++ b/lua/fastaction/window.lua
@@ -1,4 +1,5 @@
 local M = {}
+local config = require 'fastaction.config'
 local keys = require 'fastaction.keys'
 local m = {}
 
@@ -133,9 +134,26 @@ function M.popup_window(content, on_buf_create, opts)
     vim.bo[buffer].buftype = 'nofile'
 
     local line = 2 -- avoid the title and the divider i.e. start at line 2
+    local brackets = config.get().brackets or { '[', ']' }
+    local more_msg_indent =
+        -- border
+        1
+        -- left bracket
+        + #brackets[1]
+        -- key
+        + 1
+        -- right bracket
+        + #brackets[2]
     local chars = math.floor((#content - 2) / (26 - #keys.filter_alpha_keys(opts.dismiss_keys)))
     for _, _ in pairs(content) do
-        vim.api.nvim_buf_add_highlight(buffer, m.namespace, 'MoreMsg', line, 0, 3 + chars)
+        vim.api.nvim_buf_add_highlight(
+            buffer,
+            m.namespace,
+            'MoreMsg',
+            line,
+            0,
+            more_msg_indent + chars
+        )
         line = line + 1
     end
     vim.api.nvim_set_option_value('modifiable', false, { buf = buffer })


### PR DESCRIPTION
- Adds `brackets` option.
- Adjust highlight group indent of MoreMsg based on length of brackets


```lua
opts = {
  brackets = { "..", ".." }
}
```
<img width="717" alt="image" src="https://github.com/user-attachments/assets/1280b898-e8a7-43f8-acbc-20d79d09fc64" />

```lua
opts = {
  brackets = { "..", ".." }
}
```

<img width="502" alt="image" src="https://github.com/user-attachments/assets/8caaca5e-8e6d-4452-b2ab-c6a18e9bb5d0" />


```lua
opts = {
  brackets = { "", "" }
}
```
<img width="660" alt="image" src="https://github.com/user-attachments/assets/c6dbed47-b0b9-4845-9aa4-f062367fc1ba" />

```lua
opts = {
  brackets = { "(", ")" }
}
```
<img width="668" alt="image" src="https://github.com/user-attachments/assets/05a2ee69-36af-4eeb-b70c-dfaefa47e4fb" />

