### PR TITLE
feat!: improve control of highlight control

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Using `lazy.nvim`
     border = "rounded",
     hide_cursor = true,
     highlight = {
+      action = "MoreMsg",
       divider = "FloatBorder",
       key = "MoreMsg",
+      source = "Comment",
       title = "Title",
       window = "NormalFloat",
     },
@@ -78,8 +80,10 @@ in the prompt.
     border = "rounded",
     hide_cursor = true,
     highlight = {
+      action = "MoreMsg",
       divider = "FloatBorder",
       key = "MoreMsg",
+      source = "Comment",
       title = "Title",
       window = "NormalFloat",
     },

--- a/lua/fastaction/config.lua
+++ b/lua/fastaction/config.lua
@@ -13,6 +13,8 @@ m.defaults = {
         highlight = {
             divider = 'FloatBorder',
             key = 'MoreMsg',
+            action = 'MoreMsg',
+            source = 'Comment',
             title = 'Title',
             window = 'NormalFloat',
         },

--- a/lua/fastaction/init.lua
+++ b/lua/fastaction/init.lua
@@ -65,7 +65,7 @@ function M.select(items, opts, on_choice)
     ---@type Option[]
     local options = {}
 
-    ---@type string[]
+    ---@type PopupLine[]
     local content = {}
 
     local valid_keys = keys.generate_keys(#items, m.keys, conf.dismiss_keys)
@@ -108,15 +108,23 @@ function M.select(items, opts, on_choice)
     for i, option in ipairs(options) do
         local spacing = largest_char_count + 1 - option.char_count
 
-        content[i] = string.format(
-            '%s%s%s %s%s%s',
-            brackets[1],
-            option.key,
-            brackets[2],
-            option.name,
-            string.rep(' ', spacing),
-            option.right_section
-        )
+        local source_text = ''
+        local action_text = option.name:gsub('(%[[a-z_-]+%])%s*$', function(source)
+            source_text = source
+            return ''
+        end)
+
+        content[i] = {
+            {
+                text = string.format('%s%s%s', brackets[1], option.key, brackets[2]),
+                highlight = conf.popup.highlight.key,
+            },
+            { text = ' ' },
+            { text = action_text, highlight = conf.popup.highlight.action },
+            { text = source_text, highlight = conf.popup.highlight.source },
+            { text = string.rep(' ', spacing) },
+            { text = option.right_section },
+        }
     end
 
     table.sort(options, function(a, b) return (a.order or 0) < (b.order or 0) end)

--- a/lua/fastaction/types.lua
+++ b/lua/fastaction/types.lua
@@ -15,6 +15,12 @@
 ---@field key string
 ---@field order integer
 
+---@class PopupLineSection
+---@field text string
+---@field highlight? string
+---
+---@alias PopupLine PopupLineSection[]
+
 ---@class WindowOpts
 ---@field title? string | boolean
 ---@field divider? string


### PR DESCRIPTION
- Content passed into window.popup is now a table of highlight annotated segments
- Makes it easier to reason about how to apply highlights
- This commit adds a new highlight option for "source" the conditional segment after the action description

BREAKING CHANGE: change how highlights are applied and extracts some text from the action text itself in order to apply highlight to source

---

<img width="665" alt="image" src="https://github.com/user-attachments/assets/66c23eae-cbcb-46ab-8beb-ad6894e6477f" />  

(shows that rendering works, has applied highlight to source as well)

<img width="723" alt="image" src="https://github.com/user-attachments/assets/ccea4309-49ea-453f-9236-ac18b05b1e92" />  

(this additionally sets the action text highlight group)

<img width="718" alt="image" src="https://github.com/user-attachments/assets/e040b179-d568-4b2b-8616-fdbc4fdaa268" />  

(last one is what I use in my config)

### Notes on the implementation

Hi @Chaitanyabsprip I wanted to add a highlight to the source part `[lua_ls]` for example but found that going the path of the existing code meant adding more string manipulation and feared that one would loose sight of it all at some point.

So I changed the approach to passing annotated line segments as content to the popup instead. That simplifies the render logic in window at a little extra complexity in init. That part I think is worth it.

I first thought that the `right_section` was where `[lua_ls]` came from, but at some point realized that the source was a part of the action text itself. In this PR I extract that part to make to be able to easily add the highlight group. But maybe this breaks with the way you had it intended to work with `format_right_section` (or is that something else?).

What is `right_section` anyway?
