### PR TITLE
fix: make brackets optional

### DIFF
--- a/lua/fastaction/types.lua
+++ b/lua/fastaction/types.lua
@@ -49,7 +49,7 @@
 ---`vim.ui.select`
 ---@field fallback_threshold? integer
 ---@field format_right_section? fun(item: LspCodeActionItem): string
----@field brackets table<string, string>
+---@field brackets? table<string, string>
 
 ---@class PopupConfig
 ---Title of the popup.


### PR DESCRIPTION
The newly added feature added a "brackets" key to the opts table,
however not as optional. This commit makes it "brackets" optional.
