### PR TITLE
fix: make spaces same color as text

### DIFF
--- a/lua/fastaction/init.lua
+++ b/lua/fastaction/init.lua
@@ -99,10 +99,10 @@ function M.select(items, opts, on_choice)
                 text = string.format('%s%s%s', brackets[1], option.key, brackets[2]),
                 highlight = conf.popup.highlight.key,
             },
-            { text = ' ' },
+            { text = ' ', highlight = conf.popup.highlight.window },
             { text = action_text, highlight = conf.popup.highlight.action },
             { text = source_text, highlight = conf.popup.highlight.source },
-            { text = string.rep(' ', spacing) },
+            { text = string.rep(' ', spacing), highlight = conf.popup.highlight.window },
             { text = option.right_section },
         }
     end
@@ -122,7 +122,8 @@ function M.select(items, opts, on_choice)
     local winopts = vim.tbl_deep_extend('keep', opts, conf.popup)
     winopts.relative = opts.relative or winopts.relative or 'editor'
     winopts.dismiss_keys = conf.dismiss_keys
-    window.popup_window(content, setup_keymaps, winopts)
+    local window_highlight = conf.popup.highlight.window
+    window.popup_window(content, setup_keymaps, winopts, window_highlight)
 end
 
 ---@param opts FastActionConfig

--- a/lua/fastaction/window.lua
+++ b/lua/fastaction/window.lua
@@ -94,8 +94,9 @@ end
 ---@param content PopupLine[]
 ---@param on_buf_create fun(buffer: integer) | nil
 ---@param opts WindowOpts | SelectOpts
+---@param window_highlight string
 ---@return integer, integer
-function M.popup_window(content, on_buf_create, opts)
+function M.popup_window(content, on_buf_create, opts, window_highlight)
     vim.validate {
         content = { content, 't' },
         on_buf_create = { on_buf_create, 'f' },
@@ -117,7 +118,7 @@ function M.popup_window(content, on_buf_create, opts)
     local width = 0
     for i, line in ipairs(content) do
         -- Clean up the input and add left pad.
-        table.insert(line, 1, { text = ' ' })
+        table.insert(line, 1, { text = ' ', highlight = window_highlight })
         local line_str = assemble_line(line)
         local line_width = vim.fn.strdisplaywidth(line_str)
         width = math.max(line_width, width)


### PR DESCRIPTION
The spaces aren't given a highlight group, and as a result end up being a different color. I set the highlight for each of them. Not sure if this is the best way to add it, but it does work. Let me know what changes should be made if necessary!